### PR TITLE
Pin linux kernel version to 6.1.6

### DIFF
--- a/modules/configuration/framework-nixos-1/default.nix
+++ b/modules/configuration/framework-nixos-1/default.nix
@@ -15,12 +15,17 @@
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
   boot.loader.efi.efiSysMountPoint = "/boot/efi";
-  boot.kernelPackages = pkgs.linuxPackages_latest;
+
   # Setup keyfile
   boot.initrd.secrets = {
     "/crypto_keyfile.bin" = null;
   };
-
+  # FIXME(2023-02-03): pin to kernel 6.1.6 to get brigthness keys working. Linux > 6.1.6
+  # seems to have introduced a regression.
+  # See https://community.frame.work/t/solved-12th-gen-not-sending-xf86monbrightnessup-down/20605/51
+  boot.kernelPackages = pkgs.linuxPackagesFor (pkgs.linux_6_1.override {
+    argsOverride = { version = "6.1.6"; };
+  });
   networking.hostName = "framework-nixos-1"; # Define your hostname.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
 
@@ -54,7 +59,7 @@
   # Enable the X11 windowing system.
   services.xserver.enable = true;
 
-  # Enable the GNOME Desktop Environment.
+ # Enable the GNOME Desktop Environment.
   services.xserver.displayManager.gdm.enable = true;
   services.xserver.desktopManager.gnome.enable = true;
 


### PR DESCRIPTION
pin to kernel 6.1.6 to get brigthness keys working.

Linux > 6.1.6 seems to have introduced a regression.
See https://community.frame.work/t/solved-12th-gen-not-sending-xf86monbrightnessup-down/20605/51