### PR TITLE
Track 6_1 kernel release

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1672244468,
-        "narHash": "sha256-xaZb8AZqoXRCSqPusCk4ouf+fUNP8UJdafmMTF1Ltlw=",
+        "lastModified": 1674440933,
+        "narHash": "sha256-CASRcD/rK3fn5vUCti3jzry7zi0GsqRsBohNq9wPgLs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "89a8ba0b5b43b3350ff2e3ef37b66736b2ef8706",
+        "rev": "65c47ced082e3353113614f77b1bc18822dc731f",
         "type": "github"
       },
       "original": {
@@ -42,13 +42,29 @@
         "type": "github"
       }
     },
+    "nixos-hardware": {
+      "locked": {
+        "lastModified": 1674550793,
+        "narHash": "sha256-ljJlIFQZwtBbzWqWTmmw2O5BFmQf1A/DspwMOQtGXHk=",
+        "owner": "NixOS",
+        "repo": "nixos-hardware",
+        "rev": "b7ac0a56029e4f9e6743b9993037a5aaafd57103",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixos-hardware",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674242456,
-        "narHash": "sha256-yBy7rCH7EiBe9+CHZm9YB5ii5GRa+MOxeW0oDEBO8SE=",
+        "lastModified": 1675237434,
+        "narHash": "sha256-YoFR0vyEa1HXufLNIFgOGhIFMRnY6aZ0IepZF5cYemo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cdead16a444a3e5de7bc9b0af8e198b11bb01804",
+        "rev": "285b3ff0660640575186a4086e1f8dc0df2874b5",
         "type": "github"
       },
       "original": {
@@ -60,11 +76,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1674466786,
-        "narHash": "sha256-UFMDwEiM8SnzuTFme0r5MsUR/InZPK+1bDKQDwpoZcc=",
+        "lastModified": 1675436568,
+        "narHash": "sha256-oiJfuMxDZPTAhTd8oe/efFaqTQzsF2sRI5ZbTw8RHlw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5bd1073f47c5e0229a70dcd764d1fceeafb5cd58",
+        "rev": "70bb20b7dc02f8d0b212079962a18c51b4cdfe07",
         "type": "github"
       },
       "original": {
@@ -76,11 +92,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1674236650,
-        "narHash": "sha256-B4GKL1YdJnII6DQNNJ4wDW1ySJVx2suB1h/v4Ql8J0Q=",
+        "lastModified": 1675309347,
+        "narHash": "sha256-D3CQ6HRDT2m3XJlrzb5jKq4vNFR5xFTEFKC7iSjlFpM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cfb43ad7b941d9c3606fb35d91228da7ebddbfc5",
+        "rev": "006c3bd4dd2f5d1d2094047f307cbf9e2b73d9c5",
         "type": "github"
       },
       "original": {
@@ -94,6 +110,7 @@
       "inputs": {
         "darwin": "darwin",
         "home-manager": "home-manager",
+        "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs",
         "nixpkgs-master": "nixpkgs-master",
         "nixpkgs-unstable": "nixpkgs-unstable"

--- a/modules/configuration/framework-nixos-1/default.nix
+++ b/modules/configuration/framework-nixos-1/default.nix
@@ -20,12 +20,7 @@
   boot.initrd.secrets = {
     "/crypto_keyfile.bin" = null;
   };
-  # FIXME(2023-02-03): pin to kernel 6.1.6 to get brigthness keys working. Linux > 6.1.6
-  # seems to have introduced a regression.
-  # See https://community.frame.work/t/solved-12th-gen-not-sending-xf86monbrightnessup-down/20605/51
-  boot.kernelPackages = pkgs.linuxPackagesFor (pkgs.linux_6_1.override {
-    argsOverride = { version = "6.1.6"; };
-  });
+  boot.kernelPackages = pkgs.linuxPackages_6_1;
   networking.hostName = "framework-nixos-1"; # Define your hostname.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
 


### PR DESCRIPTION
Cannot replicate brightness key issues with > 6.1.6.