### PR TITLE
flatpak: add module to declaratively install apps

### DIFF
--- a/modules/configuration/framework-nixos-1/default.nix
+++ b/modules/configuration/framework-nixos-1/default.nix
@@ -96,15 +96,17 @@
   # Enable touchpad support (enabled default in most desktopManager).
   # services.xserver.libinput.enable = true;
 
+  # Enable flatpak. Some addiontal config might be required.
+  # https://flatpak.org/setup/NixOS
+  services.flatpak.enable = true;
+
   # Define a user account. Don't forget to set a password with ‘passwd’.
   users.users.gmodena = {
     isNormalUser = true;
     description = "Gabriele Modena";
     extraGroups = [ "networkmanager" "wheel" "docker"];
     packages = with pkgs; [
-      firefox
       pmutils
-    #  thunderbird
     ];
   };
 

--- a/modules/flatpak/README.md
+++ b/modules/flatpak/README.md
@@ -1,0 +1,22 @@
+# flatpak
+
+Declarative flatpak manager inspired by [declarative-flatpak](https://github.com/GermanBread/declarative-flatpak) and nix-darwin's [homebrew](https://github.com/LnL7/nix-darwin/blob/master/modules/homebrew.nix) module.
+Nixos and home-manager modules are provided for system wide or user flatpak installation.
+
+# Setup
+
+Enable flatpak in `configuration.nix`:
+```nix
+services.flatpak.enable = true;
+```
+
+import the module and declare packages to install with:
+```nix
+  services.flatpak.packages = [
+    { appId = "com.brave.Browser"; origin = "flathub";  }
+    "com.obsproject.Studio"
+    "im.riot.Riot"
+  ];
+```
+
+Rebuild system - or home-manager - for changes to take place.

--- a/modules/flatpak/default.nix
+++ b/modules/flatpak/default.nix
@@ -1,0 +1,66 @@
+{ cfg, lib, pkgs, osConfig, ... }:
+with lib;
+
+let
+  cfg = config.services.flatpak;
+
+  remoteOptions = { cfg, ... }: {
+    options = {
+      name = mkOption {
+        type = types.str;
+        description = lib.mdDoc "The remote name";
+        default = "flathub";
+      };
+      location = mkOption {
+        type = types.str;
+        description = lib.mdDoc "The remote location";
+        default = "https://dl.flathub.org/repo/flathub.flatpakrepo";
+      };
+      args = mkOption {
+        type = types.nullOr types.str;
+        description = "Extra arguments to pass to flatpak remote-add";
+        default = null;
+      };
+    };
+  };
+
+  packageOptions = { cfg, ... }: {
+    options = {
+      appId = mkOption {
+        type = types.str;
+        description = lib.mdDoc "The fully qualified id of the app to install.";
+      };
+
+      commit = mkOption {
+        type = types.nullOr types.str;
+        description = lib.mdDoc "Hash id of the app commit to install";
+        default = null;
+      };
+
+      origin = mkOption {
+        type = types.str;
+        default = "flathub";
+        description = lib.mdDoc "App repository origin (default: flathub)";
+      };
+    };
+  };
+
+
+in
+{
+    packages = mkOption {
+      type = with types; listOf (coercedTo str (appId: { inherit appId; }) (submodule packageOptions));
+      default = [ ];
+      description = mkDoc ''
+        Declares a list of applications to install.
+      '';
+    };
+    remotes = mkOption {
+      type = with types; listOf (coercedTo str (name: { inherit name location; }) (submodule remoteOptions));
+      default = [{ name = "flathub"; location = "https://dl.flathub.org/repo/flathub.flatpakrepo"; }];
+      description = mkDoc ''
+        Declare a list of flatpak repositories.
+      '';
+    };
+
+}

--- a/modules/flatpak/home-manager.nix
+++ b/modules/flatpak/home-manager.nix
@@ -1,0 +1,41 @@
+{ config, lib, pkgs, osConfig, ... }:
+with lib;
+
+let
+  cfg = config.services.flatpak;
+  installation = "user";
+in
+{
+
+  options.services.flatpak = import ./default.nix { inherit cfg lib pkgs osConfig; };
+
+  config = lib.mkIf osConfig.services.flatpak.enable {
+    systemd.user.services."flatpak-managed" = {
+      Unit = {
+        After = [
+          "network.target"
+        ];
+      };
+      Install = {
+        WantedBy = [
+          "default.target"
+        ];
+      };
+      Service = {
+        Type = "oneshot";
+        ExecStart = "${import ./installer.nix {inherit cfg pkgs; installation = installation; }}";
+      };
+    };
+    home.activation = {
+      start-service = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        export PATH=${lib.makeBinPath (with pkgs; [ systemd ])}:$PATH
+
+        $DRY_RUN_CMD systemctl is-system-running -q && \
+          systemctl --user start flatpak-managed.service || true
+      '';
+    };
+
+    xdg.enable = true;
+  };
+
+}

--- a/modules/flatpak/installer.nix
+++ b/modules/flatpak/installer.nix
@@ -1,0 +1,39 @@
+{ cfg, pkgs, installation ? "system", ... }:
+
+let
+  flatpakInstallCmd = installation: { appId, origin ? "flathub", commit ? null, ... }: ''
+    ${pkgs.flatpak}/bin/flatpak --${installation} --noninteractive --no-auto-pin install ${origin} ${appId}
+    ${if commit == null
+        then '' ''
+        else ''${pkgs.flatpak}/bin/flatpak --${installation} unpdate --commit="${commit}" ${origin} ${appId}
+    ''}'';
+
+  flatpakAddRemoteCmd = installation: { name, location, args ? null, ... }: ''
+    ${pkgs.flatpak}/bin/flatpak remote-add --${installation} --if-not-exists ${if args == null then "" else args} ${name} ${location}
+  '';
+  flatpakAddRemote = installation: remotes: map (flatpakAddRemoteCmd installation) remotes;
+  flatpakInstall = installation: packages: map (flatpakInstallCmd installation) packages;
+
+  mkFlatpakInstallCmd = installation: packages: builtins.foldl' (x: y: x + y) '''' (flatpakInstall installation packages);
+  mkFlatpakAddRemoteCmd = installation: remotes: builtins.foldl' (x: y: x + y) '''' (flatpakAddRemote installation remotes);
+  mkFlatpakInstallScript = installation: pkgs.writeShellScript "flatpak-managed-install" ''
+    # This script is triggered at build time by a transient systemd unit.
+    set -eu
+
+    # Configure remotes
+    ${mkFlatpakAddRemoteCmd installation cfg.remotes}
+
+    # Insall packages
+    ${mkFlatpakInstallCmd installation cfg.packages}
+  '';
+in
+    pkgs.writeShellScript "flatpak-managed-install" ''
+        # This script is triggered at build time by a transient systemd unit.
+        set -eu
+
+        # Configure remotes
+        ${mkFlatpakAddRemoteCmd installation cfg.remotes}
+
+        # Insall packages
+        ${mkFlatpakInstallCmd installation cfg.packages}
+    ''

--- a/modules/flatpak/nixos.nix
+++ b/modules/flatpak/nixos.nix
@@ -1,0 +1,28 @@
+{ config, lib, pkgs, osConfig, ... }:
+with lib;
+
+let
+  cfg = config.services.flatpak;
+  installation = "system";
+in
+{
+  options.services.flatpak = import ./default.nix { inherit cfg lib pkgs osConfig lib; };
+
+  config = lib.mkIf osConfig.services.flatpak.enable {
+    systemd.services."flatpak-managed" = {
+      Unit = {
+        After = [
+          "network.target"
+        ];
+      };
+      Install = {
+        WantedBy = [
+          "default.target"
+        ];
+      };
+      serviceConfig = {
+        Type = "oneshot";
+        ExecStart = "${import ./installer.nix {inherit cfg pkgs; installation = installation; }}";
+      };
+    };
+  }

--- a/modules/home-manager/desktop/nixos/default.nix
+++ b/modules/home-manager/desktop/nixos/default.nix
@@ -14,7 +14,7 @@ let
 in
 
 {
-  imports = [../../default.nix ../flatpak/home-manager.nix ];
+  imports = [../../default.nix ../../../flatpak/home-manager.nix ];
 
   services.flatpak.packages = [
     { appId = "com.brave.Browser"; origin = "flathub";  }

--- a/modules/home-manager/desktop/nixos/default.nix
+++ b/modules/home-manager/desktop/nixos/default.nix
@@ -14,8 +14,13 @@ let
 in
 
 {
-  imports = [../../default.nix ];
- 
+  imports = [../../default.nix ../flatpak/home-manager.nix ];
+
+  services.flatpak.packages = [
+    { appId = "com.brave.Browser"; origin = "flathub";  }
+    "com.obsproject.Studio"
+    "im.riot.Riot"
+  ];
   home.packages = with pkgs; [
     firefox
     _1password-gui


### PR DESCRIPTION
Add home-manager and nixos modules to wrap flatpak
and install applications declaratively.