### PR TITLE
nixos: desktop: enable fractional scaling.

### DIFF
--- a/modules/home-manager/desktop/nixos/default.nix
+++ b/modules/home-manager/desktop/nixos/default.nix
@@ -59,4 +59,10 @@ in
     steam-rom-manager
     quickemu
   ];
+  # Enable fractional scaling for Gnome DM.
+  dconf.settings = {
+    "org/gnome/mutter" = {
+      experimental-features = [ "scale-monitor-framebuffer" ];
+    };
+  };
 }


### PR DESCRIPTION
Set experimental Gnome dconf setting to enable fractional scaling.