### PR TITLE
nixpkgs: update to 24.05.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -43,16 +43,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1714043624,
-        "narHash": "sha256-Xn2r0Jv95TswvPlvamCC46wwNo8ALjRCMBJbGykdhcM=",
+        "lastModified": 1717527182,
+        "narHash": "sha256-vWSkg6AMok1UUQiSYVdGMOXKD2cDFnajITiSi0Zjd1A=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "86853e31dc1b62c6eeed11c667e8cdd0285d4411",
+        "rev": "845a5c4c073f74105022533907703441e0464bc3",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-23.11",
+        "ref": "release-24.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -75,16 +75,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715106579,
-        "narHash": "sha256-gZMgKEGiK6YrwGBiccZ1gemiUwjsZ1Zv49KYOgmX2fY=",
+        "lastModified": 1718208800,
+        "narHash": "sha256-US1tAChvPxT52RV8GksWZS415tTS7PV42KTc2PNDBmc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8be0d8a1ed4f96d99b09aa616e2afd47acc3da89",
+        "rev": "cc54fb41d13736e92229c21627ea4f22199fee6b",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,13 +4,13 @@
   inputs = {
     flatpaks.url = "github:gmodena/nix-flatpak/main";
 
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     nixpkgs-master.url = "github:nixos/nixpkgs/master";
 
     darwin.url = "github:LnL7/nix-darwin";
     darwin.inputs.nixpkgs.follows = "nixpkgs";
-    home-manager.url = "github:nix-community/home-manager/release-23.11";
+    home-manager.url = "github:nix-community/home-manager/release-24.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
 
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";

--- a/modules/configuration/nixos/default.nix
+++ b/modules/configuration/nixos/default.nix
@@ -50,7 +50,7 @@
   # gsettings reset org.gnome.desktop.input-sources sources
   # After nixos-rebuild switch.
   # TODO(2023-02-03): look at home-manager's dconf module;
-  services.xserver.xkbOptions = "caps:swapescape";
+  services.xserver.xkb.options = "caps:swapescape";
 
   # Enable CUPS to print documents.
   # services.printing.enable = true;

--- a/modules/configuration/nixos/framework-nixos-1/default.nix
+++ b/modules/configuration/nixos/framework-nixos-1/default.nix
@@ -20,7 +20,7 @@
   boot.initrd.secrets = {
     "/crypto_keyfile.bin" = null;
   };
-  boot.kernelPackages = pkgs.linuxPackages_6_1;
+  boot.kernelPackages = pkgs.linuxPackages_latest;
   networking.hostName = "framework-nixos-1"; # Define your hostname.
   # networking.wireless.enable = true;  # Enables wireless support via wpa_supplicant.
 
@@ -63,8 +63,8 @@
 
   # Configure keymap in X11
   services.xserver = {
-    layout = "us";
-    xkbVariant = "";
+    xkb.layout = "us";
+    xkb.variant = "";
   };
 
   # Enable CUPS to print documents.
@@ -123,10 +123,10 @@
   environment.gnome.excludePackages = (with pkgs; [
         gnome-photos
         gnome-tour
+        gedit # text editor
       ]) ++ (with pkgs.gnome; [
         cheese # webcam tool
         gnome-music
-        gedit # text editor
         epiphany # web browser
         geary # email reader
         gnome-characters

--- a/modules/home-manager/desktop/nixos/default.nix
+++ b/modules/home-manager/desktop/nixos/default.nix
@@ -1,15 +1,15 @@
 { lib, config, pkgs, flake-inputs, ... }:
 let
   paperwm-develop = pkgs.gnomeExtensions.paperwm.overrideAttrs (old: {
-    version = "39";
+    version = "46.11.2";
 
-    # 2023-12-16: pin gnome45 release. Required as part of the 
-    # nixpkgs 23.11 update cycle.
+    # 2024-06-13: pin Gnome46 release. Required as part of the
+    # nixpkgs 24.05 update cycle.
     src = pkgs.fetchFromGitHub {
       owner = "paperwm";
       repo = "PaperWM";
-      rev = "6bead84704bf4db8fb7eb2ecd94bb1212059f7c3";
-      hash = "sha256-lvMf3rg1wooXG++VvwreSZeOE8TOgTgfVU7SDIpYdI0=";
+      rev = "2ab1d62eaff52c83c3c4a9bf804aa27382936beb"; # v46.11.2
+      hash = "sha256-EGS6XyRqTiKiJ5EQP5O8jHK9rE2hWK1Sf7Vuw2eLcWg=";
     };
   });
 
@@ -45,7 +45,6 @@ in
     gnomeExtensions.appindicator
     synology-drive-client
     powertop
-    albert
     gcc
     gnome.gnome-tweaks
     protonvpn-gui


### PR DESCRIPTION
Update nixpkgs to latest release.
Start tracking linux latest kernel packages.