### PR TITLE
framework: enable podman.

### DIFF
--- a/modules/configuration/nixos/framework-nixos-1/default.nix
+++ b/modules/configuration/nixos/framework-nixos-1/default.nix
@@ -71,12 +71,20 @@
   # Enable CUPS to print documents.
   services.printing.enable = true;
 
-  # https://nixos.wiki/wiki/Docker
-  virtualisation.docker.enable = true;
-  virtualisation.docker.rootless = {
-    enable = true;
-    setSocketVariable = true;
+  # https://nixos.wiki/wiki/Podman
+  virtualisation.containers.enable = true;
+  virtualisation = {
+    podman = {
+      enable = true;
+
+      # Create a `docker` alias for podman, to use it as a drop-in replacement
+      dockerCompat = true;
+
+      # Required for containers under podman-compose to be able to talk to each other.
+      defaultNetwork.settings.dns_enabled = true;
+    };
   };
+
   # Enable sound with pipewire.
   sound.enable = true;
   hardware.pulseaudio.enable = false;
@@ -119,6 +127,9 @@
   environment.systemPackages = with pkgs; [
   #  vim # Do not forget to add an editor to edit configuration.nix! The Nano editor is also installed by default.
   #  wget
+    dive
+    podman-tui
+    docker-compose
   ];
 
   environment.gnome.excludePackages = (with pkgs; [


### PR DESCRIPTION
Install podman as a drop-in replacement for rootles docker.